### PR TITLE
Only handle '.css' files in writeFile

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -7,6 +7,7 @@ import { DtsCreator } from './dts-creator';
 import { DtsContent } from './dts-content';
 
 const glob = util.promisify(_glob);
+const cssExtRegex = /\.css$/i;
 
 interface RunOptions {
   pattern?: string;
@@ -31,7 +32,7 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
   });
 
   const writeFile = async (f: string): Promise<void> => {
-    if (!f.endsWith('.css')) {
+    if (!cssExtRegex.test(f)) {
       return;
     }
     try {

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,6 +31,9 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
   });
 
   const writeFile = async (f: string): Promise<void> => {
+    if (!f.endsWith('.css')) {
+      return;
+    }
     try {
       const content: DtsContent = await creator.create(f, undefined, !!options.watch);
       await content.writeFile();


### PR DESCRIPTION
Chokidar can trigger `writeFile` for files that `glob()` does not, so adding an extra precaution here to skip avoidable error logs.

In our case, starting `watch` on pattern `packages/**/*.module.css` in a monorepo has chokidar trigger for files like:
- `packages/apps/WebApp/node_modules/.bin/lint-staged`
- `packages/apps/WebApp/node_modules/.bin/prettier`

It seems that the issue is caused by `chokidar` using `glob-parent` that handles recursive patterns in a different way than `glob`.

Error screenshot  
<img width="736" alt="image" src="https://user-images.githubusercontent.com/658586/146776765-04c613f9-c870-43d8-9ef4-8047f8789138.png">
